### PR TITLE
Add feedback after workflow execution

### DIFF
--- a/src/components/workflow/WorkflowExecutor.tsx
+++ b/src/components/workflow/WorkflowExecutor.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { Box, Button, Typography, Paper, Card, CardContent, Grid, Chip, Divider } from '@mui/material';
+import { WorkflowFeedback } from './WorkflowFeedback';
 import { WorkflowProgress } from '../../types/workflow';
 import { WorkflowProgressStepper } from './WorkflowProgressStepper';
 import { WorkflowTemplate } from '../../types/workflow-builder';
@@ -349,58 +350,10 @@ export const WorkflowExecutor: React.FC<WorkflowExecutorProps> = ({ workflow }) 
               <ResultDisplay result={result} />
             </Box>
           )}
-          <Box sx={{ 
-            mt: 4, 
-            display: 'flex', 
-            flexDirection: 'column', 
-            alignItems: 'center',
-            gap: 2 
-          }}>
-            <Typography variant="subtitle1" color="text.secondary">
-              Was this result helpful?
-            </Typography>
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <Button
-                variant={feedback === 'positive' ? 'contained' : 'outlined'}
-                onClick={() => setFeedback('positive')}
-                sx={{
-                  minWidth: '120px',
-                  color: feedback === 'positive' ? 'white' : 'success.main',
-                  borderColor: 'success.main',
-                  bgcolor: feedback === 'positive' ? 'success.main' : 'transparent',
-                  '&:hover': {
-                    bgcolor: feedback === 'positive' ? 'success.dark' : 'success.light',
-                    borderColor: 'success.main',
-                  }
-                }}
-              >
-                👍 Yes
-              </Button>
-              <Button
-                variant={feedback === 'negative' ? 'contained' : 'outlined'}
-                onClick={() => setFeedback('negative')}
-                sx={{
-                  minWidth: '120px',
-                  color: feedback === 'negative' ? 'white' : 'error.main',
-                  borderColor: 'error.main',
-                  bgcolor: feedback === 'negative' ? 'error.main' : 'transparent',
-                  '&:hover': {
-                    bgcolor: feedback === 'negative' ? 'error.dark' : 'error.light',
-                    borderColor: 'error.main',
-                  }
-                }}
-              >
-                👎 No
-              </Button>
-            </Box>
-            {feedback && (
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                {feedback === 'positive' 
-                  ? 'Thank you for your feedback!' 
-                  : 'Thanks for letting us know. We\'ll work on improving this.'}
-              </Typography>
-            )}
-          </Box>
+          <WorkflowFeedback 
+            feedback={feedback}
+            onFeedbackChange={setFeedback}
+          />
           <Button
             variant="contained"
             onClick={handleReset}

--- a/src/components/workflow/WorkflowExecutor.tsx
+++ b/src/components/workflow/WorkflowExecutor.tsx
@@ -96,10 +96,10 @@ export const WorkflowExecutor: React.FC<WorkflowExecutorProps> = ({ workflow }) 
       
       // Step 2: Sending to API endpoint
       updateProgress(1, 'in_progress', 'Sending data to API endpoint...');
-      const response = await executeWorkflowAPI(formData);
       
       // Step 3: Processing
       updateProgress(2, 'in_progress', 'Processing response...');
+      const response = await executeWorkflowAPI(formData);
       
       // Step 4: Completing
       updateProgress(3, 'in_progress', 'Finalizing...');

--- a/src/components/workflow/WorkflowExecutor.tsx
+++ b/src/components/workflow/WorkflowExecutor.tsx
@@ -353,6 +353,7 @@ export const WorkflowExecutor: React.FC<WorkflowExecutorProps> = ({ workflow }) 
           <WorkflowFeedback 
             feedback={feedback}
             onFeedbackChange={setFeedback}
+            workflowId={workflow.id}
           />
           <Button
             variant="contained"

--- a/src/components/workflow/WorkflowExecutor.tsx
+++ b/src/components/workflow/WorkflowExecutor.tsx
@@ -19,6 +19,7 @@ export const WorkflowExecutor: React.FC<WorkflowExecutorProps> = ({ workflow }) 
   const [result, setResult] = useState<ContentTypeResponse | null>(null);
   const [error, setError] = useState<string>('');
   const [isCompleted, setIsCompleted] = useState(false);
+  const [feedback, setFeedback] = useState<'positive' | 'negative' | null>(null);
   const [progress, setProgress] = useState<WorkflowProgress>({
     currentStep: 0,
     totalSteps: 4,
@@ -132,6 +133,7 @@ export const WorkflowExecutor: React.FC<WorkflowExecutorProps> = ({ workflow }) 
     setResult(null);
     setError('');
     setIsCompleted(false);
+    setFeedback(null);
     setProgress({
       currentStep: 0,
       totalSteps: 4,
@@ -347,6 +349,58 @@ export const WorkflowExecutor: React.FC<WorkflowExecutorProps> = ({ workflow }) 
               <ResultDisplay result={result} />
             </Box>
           )}
+          <Box sx={{ 
+            mt: 4, 
+            display: 'flex', 
+            flexDirection: 'column', 
+            alignItems: 'center',
+            gap: 2 
+          }}>
+            <Typography variant="subtitle1" color="text.secondary">
+              Was this result helpful?
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Button
+                variant={feedback === 'positive' ? 'contained' : 'outlined'}
+                onClick={() => setFeedback('positive')}
+                sx={{
+                  minWidth: '120px',
+                  color: feedback === 'positive' ? 'white' : 'success.main',
+                  borderColor: 'success.main',
+                  bgcolor: feedback === 'positive' ? 'success.main' : 'transparent',
+                  '&:hover': {
+                    bgcolor: feedback === 'positive' ? 'success.dark' : 'success.light',
+                    borderColor: 'success.main',
+                  }
+                }}
+              >
+                👍 Yes
+              </Button>
+              <Button
+                variant={feedback === 'negative' ? 'contained' : 'outlined'}
+                onClick={() => setFeedback('negative')}
+                sx={{
+                  minWidth: '120px',
+                  color: feedback === 'negative' ? 'white' : 'error.main',
+                  borderColor: 'error.main',
+                  bgcolor: feedback === 'negative' ? 'error.main' : 'transparent',
+                  '&:hover': {
+                    bgcolor: feedback === 'negative' ? 'error.dark' : 'error.light',
+                    borderColor: 'error.main',
+                  }
+                }}
+              >
+                👎 No
+              </Button>
+            </Box>
+            {feedback && (
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                {feedback === 'positive' 
+                  ? 'Thank you for your feedback!' 
+                  : 'Thanks for letting us know. We\'ll work on improving this.'}
+              </Typography>
+            )}
+          </Box>
           <Button
             variant="contained"
             onClick={handleReset}

--- a/src/components/workflow/WorkflowFeedback.tsx
+++ b/src/components/workflow/WorkflowFeedback.tsx
@@ -80,7 +80,7 @@ export const WorkflowFeedback: React.FC<WorkflowFeedbackProps> = ({
           borderColor: feedback === 'positive' ? 'success.main' : 'error.main',
           borderRadius: 1,
           bgcolor: feedback === 'positive' ? 'success.light' : 'error.light',
-          color: feedback === 'positive' ? 'success.dark' : 'error.dark'
+          color: '#ffffff'
         }}>
           <Typography variant="body1" sx={{ fontWeight: 500 }}>
             {feedback === 'positive' 

--- a/src/components/workflow/WorkflowFeedback.tsx
+++ b/src/components/workflow/WorkflowFeedback.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
 import { Box, Button, Typography } from '@mui/material';
+import { workflowService } from '../../services/workflow-service';
 
 interface WorkflowFeedbackProps {
   feedback: 'positive' | 'negative' | null;
   onFeedbackChange: (feedback: 'positive' | 'negative') => void;
+  workflowId: string;
 }
 
 export const WorkflowFeedback: React.FC<WorkflowFeedbackProps> = ({
   feedback,
   onFeedbackChange,
+  workflowId,
 }) => {
+  const handleFeedback = async (newFeedback: 'positive' | 'negative') => {
+    try {
+      await workflowService.submitFeedback(workflowId, newFeedback);
+      onFeedbackChange(newFeedback);
+    } catch (error) {
+      console.error('Failed to submit feedback:', error);
+      // Still update UI state even if API call fails
+      onFeedbackChange(newFeedback);
+    }
+  };
   return (
     <Box sx={{ 
       mt: 4, 
@@ -24,7 +37,7 @@ export const WorkflowFeedback: React.FC<WorkflowFeedbackProps> = ({
       <Box sx={{ display: 'flex', gap: 2 }}>
         <Button
           variant={feedback === 'positive' ? 'contained' : 'outlined'}
-          onClick={() => onFeedbackChange('positive')}
+          onClick={() => handleFeedback('positive')}
           sx={{
             minWidth: '120px',
             color: feedback === 'positive' ? 'white' : 'success.main',
@@ -40,7 +53,7 @@ export const WorkflowFeedback: React.FC<WorkflowFeedbackProps> = ({
         </Button>
         <Button
           variant={feedback === 'negative' ? 'contained' : 'outlined'}
-          onClick={() => onFeedbackChange('negative')}
+          onClick={() => handleFeedback('negative')}
           sx={{
             minWidth: '120px',
             color: feedback === 'negative' ? 'white' : 'error.main',

--- a/src/components/workflow/WorkflowFeedback.tsx
+++ b/src/components/workflow/WorkflowFeedback.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Box, Button, Typography } from '@mui/material';
+
+interface WorkflowFeedbackProps {
+  feedback: 'positive' | 'negative' | null;
+  onFeedbackChange: (feedback: 'positive' | 'negative') => void;
+}
+
+export const WorkflowFeedback: React.FC<WorkflowFeedbackProps> = ({
+  feedback,
+  onFeedbackChange,
+}) => {
+  return (
+    <Box sx={{ 
+      mt: 4, 
+      display: 'flex', 
+      flexDirection: 'column', 
+      alignItems: 'center',
+      gap: 2 
+    }}>
+      <Typography variant="subtitle1" color="text.secondary">
+        Was this result helpful?
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <Button
+          variant={feedback === 'positive' ? 'contained' : 'outlined'}
+          onClick={() => onFeedbackChange('positive')}
+          sx={{
+            minWidth: '120px',
+            color: feedback === 'positive' ? 'white' : 'success.main',
+            borderColor: 'success.main',
+            bgcolor: feedback === 'positive' ? 'success.main' : 'transparent',
+            '&:hover': {
+              bgcolor: feedback === 'positive' ? 'success.dark' : 'success.light',
+              borderColor: 'success.main',
+            }
+          }}
+        >
+          👍 Yes
+        </Button>
+        <Button
+          variant={feedback === 'negative' ? 'contained' : 'outlined'}
+          onClick={() => onFeedbackChange('negative')}
+          sx={{
+            minWidth: '120px',
+            color: feedback === 'negative' ? 'white' : 'error.main',
+            borderColor: 'error.main',
+            bgcolor: feedback === 'negative' ? 'error.main' : 'transparent',
+            '&:hover': {
+              bgcolor: feedback === 'negative' ? 'error.dark' : 'error.light',
+              borderColor: 'error.main',
+            }
+          }}
+        >
+          👎 No
+        </Button>
+      </Box>
+      {feedback && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          {feedback === 'positive' 
+            ? 'Thank you for your feedback!' 
+            : 'Thanks for letting us know. We\'ll work on improving this.'}
+        </Typography>
+      )}
+    </Box>
+  );
+};

--- a/src/components/workflow/WorkflowFeedback.tsx
+++ b/src/components/workflow/WorkflowFeedback.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Box, Button, Typography } from '@mui/material';
 import { workflowService } from '../../services/workflow-service';
 
@@ -13,14 +13,18 @@ export const WorkflowFeedback: React.FC<WorkflowFeedbackProps> = ({
   onFeedbackChange,
   workflowId,
 }) => {
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
   const handleFeedback = async (newFeedback: 'positive' | 'negative') => {
+    if (isSubmitted) return; // Prevent multiple submissions
+    
     try {
       await workflowService.submitFeedback(workflowId, newFeedback);
       onFeedbackChange(newFeedback);
+      setIsSubmitted(true); // Mark as submitted after successful feedback
     } catch (error) {
       console.error('Failed to submit feedback:', error);
-      // Still update UI state even if API call fails
-      onFeedbackChange(newFeedback);
+      // Only update UI state if API call succeeds
     }
   };
   return (
@@ -38,6 +42,7 @@ export const WorkflowFeedback: React.FC<WorkflowFeedbackProps> = ({
         <Button
           variant={feedback === 'positive' ? 'contained' : 'outlined'}
           onClick={() => handleFeedback('positive')}
+          disabled={isSubmitted}
           sx={{
             minWidth: '120px',
             color: feedback === 'positive' ? 'white' : 'success.main',
@@ -54,6 +59,7 @@ export const WorkflowFeedback: React.FC<WorkflowFeedbackProps> = ({
         <Button
           variant={feedback === 'negative' ? 'contained' : 'outlined'}
           onClick={() => handleFeedback('negative')}
+          disabled={isSubmitted}
           sx={{
             minWidth: '120px',
             color: feedback === 'negative' ? 'white' : 'error.main',

--- a/src/components/workflow/WorkflowFeedback.tsx
+++ b/src/components/workflow/WorkflowFeedback.tsx
@@ -38,48 +38,56 @@ export const WorkflowFeedback: React.FC<WorkflowFeedbackProps> = ({
       <Typography variant="subtitle1" color="text.secondary">
         Was this result helpful?
       </Typography>
-      <Box sx={{ display: 'flex', gap: 2 }}>
-        <Button
-          variant={feedback === 'positive' ? 'contained' : 'outlined'}
-          onClick={() => handleFeedback('positive')}
-          disabled={isSubmitted}
-          sx={{
-            minWidth: '120px',
-            color: feedback === 'positive' ? 'white' : 'success.main',
-            borderColor: 'success.main',
-            bgcolor: feedback === 'positive' ? 'success.main' : 'transparent',
-            '&:hover': {
-              bgcolor: feedback === 'positive' ? 'success.dark' : 'success.light',
+      {!isSubmitted ? (
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Button
+            variant={feedback === 'positive' ? 'contained' : 'outlined'}
+            onClick={() => handleFeedback('positive')}
+            sx={{
+              minWidth: '120px',
+              color: feedback === 'positive' ? 'white' : 'success.main',
               borderColor: 'success.main',
-            }
-          }}
-        >
-          👍 Yes
-        </Button>
-        <Button
-          variant={feedback === 'negative' ? 'contained' : 'outlined'}
-          onClick={() => handleFeedback('negative')}
-          disabled={isSubmitted}
-          sx={{
-            minWidth: '120px',
-            color: feedback === 'negative' ? 'white' : 'error.main',
-            borderColor: 'error.main',
-            bgcolor: feedback === 'negative' ? 'error.main' : 'transparent',
-            '&:hover': {
-              bgcolor: feedback === 'negative' ? 'error.dark' : 'error.light',
+              bgcolor: feedback === 'positive' ? 'success.main' : 'transparent',
+              '&:hover': {
+                bgcolor: feedback === 'positive' ? 'success.dark' : 'success.light',
+                borderColor: 'success.main',
+              }
+            }}
+          >
+            👍 Yes
+          </Button>
+          <Button
+            variant={feedback === 'negative' ? 'contained' : 'outlined'}
+            onClick={() => handleFeedback('negative')}
+            sx={{
+              minWidth: '120px',
+              color: feedback === 'negative' ? 'white' : 'error.main',
               borderColor: 'error.main',
-            }
-          }}
-        >
-          👎 No
-        </Button>
-      </Box>
-      {feedback && (
-        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-          {feedback === 'positive' 
-            ? 'Thank you for your feedback!' 
-            : 'Thanks for letting us know. We\'ll work on improving this.'}
-        </Typography>
+              bgcolor: feedback === 'negative' ? 'error.main' : 'transparent',
+              '&:hover': {
+                bgcolor: feedback === 'negative' ? 'error.dark' : 'error.light',
+                borderColor: 'error.main',
+              }
+            }}
+          >
+            👎 No
+          </Button>
+        </Box>
+      ) : (
+        <Box sx={{ 
+          p: 2, 
+          border: 1, 
+          borderColor: feedback === 'positive' ? 'success.main' : 'error.main',
+          borderRadius: 1,
+          bgcolor: feedback === 'positive' ? 'success.light' : 'error.light',
+          color: feedback === 'positive' ? 'success.dark' : 'error.dark'
+        }}>
+          <Typography variant="body1" sx={{ fontWeight: 500 }}>
+            {feedback === 'positive' 
+              ? '👍 Thank you for your positive feedback!' 
+              : '👎 Thanks for letting us know. We\'ll work on improving this.'}
+          </Typography>
+        </Box>
       )}
     </Box>
   );

--- a/src/services/workflow-service.ts
+++ b/src/services/workflow-service.ts
@@ -88,6 +88,17 @@ export class WorkflowService {
 
     return execution;
   }
+
+  async submitFeedback(workflowId: string, feedback: 'positive' | 'negative'): Promise<any> {
+    return this.fetchApi('/workflow-feedback', {
+      method: 'POST',
+      body: JSON.stringify({
+        workflowId,
+        feedback,
+        submittedAt: new Date().toISOString(),
+      }),
+    });
+  }
 }
 
 export const workflowService = new WorkflowService();


### PR DESCRIPTION
Creates the ability for users to send basic feedback, after the workflow is executed and a response is returned. The feedback contains workflow id, is the feedback positive or negative and the date of the feedback.